### PR TITLE
No longer declaring Growl::RSpec inline.

### DIFF
--- a/lib/growl/rspec/formatter.rb
+++ b/lib/growl/rspec/formatter.rb
@@ -1,77 +1,79 @@
 require 'rspec/core/formatters/base_text_formatter'
 
-module Growl::RSpec
-  # The Growl::RSpec::Formatter depens on the growl gem
-  # (and therefore, growlnotify bin must be installed) 
-  #
-  # Use it by putting this in your spec_helper.rb
-  #    RSpec.configure do |config|
-  #       config.formatter = 'Growl::RSpec::Formatter'
-  #    end
-  #
-  # You can switch off granular growls about each spec failure via:
-  #    Growl::RSpec::Formatter.config = {
-  #      :growl_failures => false
-  #    }
-  #
-  # You can configure additional growlnotify options like:
-  #    Growl::RSpec::Formatter.growlnotify_config = {
-  #      :host => 'your.growl.host'
-  #    }
-  #
-  class Formatter < RSpec::Core::Formatters::BaseTextFormatter
+module Growl
+  module RSpec
+    # The Growl::RSpec::Formatter depens on the growl gem
+    # (and therefore, growlnotify bin must be installed) 
+    #
+    # Use it by putting this in your spec_helper.rb
+    #    RSpec.configure do |config|
+    #       config.formatter = 'Growl::RSpec::Formatter'
+    #    end
+    #
+    # You can switch off granular growls about each spec failure via:
+    #    Growl::RSpec::Formatter.config = {
+    #      :growl_failures => false
+    #    }
+    #
+    # You can configure additional growlnotify options like:
+    #    Growl::RSpec::Formatter.growlnotify_config = {
+    #      :host => 'your.growl.host'
+    #    }
+    #
+    class Formatter < ::RSpec::Core::Formatters::BaseTextFormatter
 
-    # the formatters default config hash
-    DEFAULT_CONFIG = {
-      :growl_failures => true
-    }.freeze
+      # the formatters default config hash
+      DEFAULT_CONFIG = {
+        :growl_failures => true
+      }.freeze
 
-    # read the formatters config hash
-    def self.config
-      @@config ||= DEFAULT_CONFIG
-    end
+      # read the formatters config hash
+      def self.config
+        @@config ||= DEFAULT_CONFIG
+      end
 
-    # set the formatters config hash
-    def self.config=(c)
-      @@config = DEFAULT_CONFIG.dup.merge(c)
-    end
+      # set the formatters config hash
+      def self.config=(c)
+        @@config = DEFAULT_CONFIG.dup.merge(c)
+      end
 
-    # set the config hash that is passed to growlnotify gem
-    def self.growlnotify_config=(o)
-      @@_growlnotify_config = o
-    end
+      # set the config hash that is passed to growlnotify gem
+      def self.growlnotify_config=(o)
+        @@_growlnotify_config = o
+      end
 
-    # get the config hash that is passed to growlnotify gem
-    def self.growlnotify_config
-      @@_growlnotify_config ||= {}
-    end
+      # get the config hash that is passed to growlnotify gem
+      def self.growlnotify_config
+        @@_growlnotify_config ||= {}
+      end
 
-    # hook when spec failed
-    def dump_failures
-      super
-      return if failed_examples.empty?
-      if self.class.config[:growl_failures]
+      # hook when spec failed
+      def dump_failures
+        super
+        return if failed_examples.empty?
+        if self.class.config[:growl_failures]
 
-        msg = failed_examples.each_with_index.map do |example, idx|
-          ["#{idx+1}. it #{example.description}",
-           example.metadata[:execution_result][:exception]]
-        end.flatten.join("\n\n")
+          msg = failed_examples.each_with_index.map do |example, idx|
+            ["#{idx+1}. it #{example.description}",
+             example.metadata[:execution_result][:exception]]
+          end.flatten.join("\n\n")
 
-        ::Growl.notify_warning msg, {
-          :title => "#{failed_examples.size} specs failed"
+          ::Growl.notify_warning msg, {
+            :title => "#{failed_examples.size} specs failed"
+          }.merge(self.class.growlnotify_config)
+        end
+      end
+
+      # hook when all specs ran
+      def dump_summary(duration, example_count, failure_count, pending_count)
+        super(duration, example_count, failure_count, pending_count)
+
+        msg = "#{example_count} specs in total (#{pending_count} pending). "\
+              "Consumed #{duration.round(1)}s"
+        ::Growl.notify_info msg, {
+          :title => "#{failure_count} specs failed!"
         }.merge(self.class.growlnotify_config)
       end
-    end
-
-    # hook when all specs ran
-    def dump_summary(duration, example_count, failure_count, pending_count)
-      super(duration, example_count, failure_count, pending_count)
-
-      msg = "#{example_count} specs in total (#{pending_count} pending). "\
-            "Consumed #{duration.round(1)}s"
-      ::Growl.notify_info msg, {
-        :title => "#{failure_count} specs failed!"
-      }.merge(self.class.growlnotify_config)
     end
   end
 end


### PR DESCRIPTION
This was causing problems when trying to include the formatter in `.rspec` file:

**.rspec**

```
--color
--format documentation --format Growl::RSpec::Formatter
```

**console output**

```
cboyd@cboyd-air ~/workspace/myproj (master) $> b rake spec
/Users/cboyd/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/growl-rspec-0.0.1/lib/growl/rspec/formatter.rb:3:in `<top (required)>': uninitialized constant Growl (NameError)
  from /Users/cboyd/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/rspec-core-2.7.1/lib/rspec/core/configuration.rb:522:in `require'
  from /Users/cboyd/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/rspec-core-2.7.1/lib/rspec/core/configuration.rb:522:in `rescue in custom_formatter'
  from /Users/cboyd/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/rspec-core-2.7.1/lib/rspec/core/configuration.rb:519:in `custom_formatter'
  from /Users/cboyd/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/rspec-core-2.7.1/lib/rspec/core/configuration.rb:301:in `add_formatter'
  from /Users/cboyd/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/rspec-core-2.7.1/lib/rspec/core/configuration_options.rb:22:in `block in configure'
  from /Users/cboyd/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/rspec-core-2.7.1/lib/rspec/core/configuration_options.rb:22:in `each'
  from /Users/cboyd/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/rspec-core-2.7.1/lib/rspec/core/configuration_options.rb:22:in `configure'
  from /Users/cboyd/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/rspec-core-2.7.1/lib/rspec/core/command_line.rb:17:in `run'
  from /Users/cboyd/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/rspec-core-2.7.1/lib/rspec/core/runner.rb:80:in `run_in_process'
  from /Users/cboyd/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/rspec-core-2.7.1/lib/rspec/core/runner.rb:69:in `run'
  from /Users/cboyd/.rbenv/versions/1.9.3-p0/lib/ruby/gems/1.9.1/gems/rspec-core-2.7.1/lib/rspec/core/runner.rb:10:in `block in autorun'
rake aborted!
```

This change fixes this error.
