### PR TITLE
changed growl title when there are no errors

### DIFF
--- a/lib/growl/rspec/formatter.rb
+++ b/lib/growl/rspec/formatter.rb
@@ -70,9 +70,14 @@ module Growl
 
         msg = "#{example_count} specs in total (#{pending_count} pending). "\
               "Consumed #{duration.round(1)}s"
-        ::Growl.notify_info msg, {
-          :title => "#{failure_count} specs failed!"
-        }.merge(self.class.growlnotify_config)
+
+        title = if failure_count == 0
+          "All specs passed."
+        else
+          "#{failure_count} specs failed!"
+        end
+
+        ::Growl.notify_info msg, { :title => title }.merge(self.class.growlnotify_config)
       end
     end
   end


### PR DESCRIPTION
The current title is kind of confusing, because when you see "specs failed" it makes you think it didn't work, even though you see the "0" at the beginning.
