### PR TITLE
don't call super

### DIFF
--- a/lib/growl/rspec/formatter.rb
+++ b/lib/growl/rspec/formatter.rb
@@ -49,7 +49,6 @@ module Growl
 
       # hook when spec failed
       def dump_failures
-        super
         return if failed_examples.empty?
         if self.class.config[:growl_failures]
 
@@ -66,8 +65,6 @@ module Growl
 
       # hook when all specs ran
       def dump_summary(duration, example_count, failure_count, pending_count)
-        super(duration, example_count, failure_count, pending_count)
-
         msg = "#{example_count} specs in total (#{pending_count} pending). "\
               "Consumed #{duration.round(1)}s"
         ::Growl.notify_info msg, {


### PR DESCRIPTION
If you only enable `growl-rspec` formatter, you get output like this:

```
No DRb server is running. Running in local process instead ...

Run options: exclude {:capybara=>true}

Finished in 0.02603 seconds
4 examples, 0 failures
>
```

So there are no standard "...." progress dots. If I want to see them too, then I can enable two formatters, which is a feature RSpec supports. But then I get output like this:

```
No DRb server is running. Running in local process instead ...

Run options: exclude {:capybara=>true}
Run options: exclude {:capybara=>true}
....

Finished in 0.11286 seconds
4 examples, 0 failures

Finished in 0.11286 seconds
4 examples, 0 failures
>
```

Because `growl-rspec` is calling the superclass implementations of the base text formatter which prints those summaries second time. If I remove the two `super` calls, then I get what I expect (`growl-rspec` only shows the notification and the other formatter prints the dots and summaries).
