### PR TITLE
Use attributes instead of hash syntax

### DIFF
--- a/lib/growl/rspec/formatter.rb
+++ b/lib/growl/rspec/formatter.rb
@@ -59,7 +59,7 @@ module Growl
 
           msg = examples_notification.failed_examples.each_with_index.map do |example, idx|
             ["#{idx+1}. it #{example.description}",
-             example.metadata[:execution_result][:exception]]
+             example.metadata[:execution_result].exception]
           end.flatten.join("\n\n")
 
           ::Growl.notify_warning msg, {


### PR DESCRIPTION
Treating `metadata[:execution_result]` as a hash is deprecated. Use the attributes methods to access the data instead.
Avoid deprecation warning
